### PR TITLE
Install node from ppa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Install basics
 RUN apt-get update &&  \
     apt-get install -y git wget curl unzip ruby build-essential xvfb && \
-    curl --retry 3 -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" && \
-    tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 && \
-    rm "node-v$NODE_VERSION-linux-x64.tar.gz" && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get update &&  \
+    apt-get install -y nodejs && \
     npm install -g npm@"$NPM_VERSION" cordova@"$CORDOVA_VERSION" ionic@"$IONIC_VERSION" yarn@"$YARN_VERSION" && \
     npm cache clear && \
     gem install sass && \


### PR DESCRIPTION
I had a problem with path when I was installing global packages with the old install.

To reproduce the bug, add `npm install -g cordova ionic` and try to run ionic build. There seem to have a problem with the PATH.

I didn't try to correct the bug, instead I installed another way (following official doc from nodejs for ubuntu)

Please note that we install las 6.x and not version of NODE_VERSION, so you may not want to merge this.