### PR TITLE
typo: we want oracle-java8-installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update &&  \
     apt-get update && apt-get install -y -q python-software-properties software-properties-common  && \
     add-apt-repository ppa:webupd8team/java -y && \
     echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get update && apt-get -y install oracle-java7-installer && \
+    apt-get update && apt-get -y install oracle-java8-installer && \
 
 # Ruby
     apt-add-repository ppa:brightbox/ruby-ng -y && \


### PR DESCRIPTION
I think this is a typo, because you writed java8 above.